### PR TITLE
fix(ci): use Node 22 for Astro 7.x compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
         uses: withastro/action@v3
-        # with:
-          # path: . # The root location of your Astro project inside the repository. (optional)
-          # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-          # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        with:
+          node-version: 22
 
   deploy:
     needs: build


### PR DESCRIPTION
## Problem

The GitHub Actions **build** job is failing because `withastro/action@v3` defaults to **Node 20**, but **Astro 7.x** requires `Node >= 22.12.0`.

### Error from CI logs
```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Job: https://github.com/ZHAO20060708/ZHAO20060708.github.io/actions/runs/28113771433

## Fix

Explicitly set `node-version: 22` in the `withastro/action@v3` step to match the engine requirement in `package.json`.

## Changes
- `.github/workflows/deploy.yml`: Uncommented the `with` block and set `node-version: 22`